### PR TITLE
AGR-667 add disease-specific URLs for sources according to the indexer

### DIFF
--- a/src/main/java/org/alliancegenome/indexer/document/SourceDoclet.java
+++ b/src/main/java/org/alliancegenome/indexer/document/SourceDoclet.java
@@ -9,6 +9,7 @@ public class SourceDoclet {
 
     private SpeciesDoclet species;
     private String url;
+    private String diseaseUrl;
     private String name;
 
 }


### PR DESCRIPTION
This goes hand-in-hand with the change for the indexer repo: 
Changed the SourceDoclet class to support disease specific URLs.