### PR TITLE
Fixed search integration test

### DIFF
--- a/src/test/groovy/org/alliancegenome/api/QueryRankIntegrationSpec.groovy
+++ b/src/test/groovy/org/alliancegenome/api/QueryRankIntegrationSpec.groovy
@@ -15,12 +15,15 @@ class QueryRankIntegrationSpec extends Specification {
         def betterResult = results.find { it.id == betterResultId }
         def worseResult = results.find { it.id == worseResultId }
         def betterResultPosition = results.findIndexValues() { it.id == betterResultId }?.first()
-        def worseResultPosition = results.findIndexValues() { it.id == worseResultId }?.first()
+        def worseResultPosition = Integer.MAX_VALUE
+        //if the "worse" result falls off the end of 5k results, for this test, that's a also a success
+        if (worseResult != null) {
+            worseResultPosition = results.findIndexValues() { it.id == worseResultId }?.first()
+        }
 
         then:
         betterResult
-        worseResult
-        betterResultPosition < worseResultPosition
+        worseResult == null || betterResultPosition < worseResultPosition
 
         where:
         query                 | filter                               | betterResultId             | worseResultId             | issue


### PR DESCRIPTION
We had one test failure, when in the betterResult / worseResult test, the worse result had happily fallen out of the top 5000.   With this in, mvn verify can be added to the GoCD build process to get some additional testing of the build. 