### PR TITLE
Add just enough lucene escaping for <sup></sup> tags in allele names

### DIFF
--- a/src/main/java/org/alliancegenome/api/service/QueryManipulationService.java
+++ b/src/main/java/org/alliancegenome/api/service/QueryManipulationService.java
@@ -1,11 +1,20 @@
 package org.alliancegenome.api.service;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javax.enterprise.context.RequestScoped;
+import java.util.regex.Pattern;
 
 @RequestScoped
 public class QueryManipulationService {
 
+    private static final String ESCAPE_CHARS = "[\\<\\>\\/]";
+    private static final Pattern LUCENE_PATTERN = Pattern.compile(ESCAPE_CHARS);
+    private static final String REPLACEMENT_STRING = "\\\\$0";
+
+
     public String processQuery(String query) {
+        query = luceneEscape(query);
         query = escapeColons(query);
         return query;
 
@@ -24,4 +33,13 @@ public class QueryManipulationService {
         query = query.replaceAll("(__)([a-zA-Z_]+)\\\\:","$2:");
         return query;
     }
+
+    private String luceneEscape(String value) {
+        if (StringUtils.isEmpty(value)) {
+            return value;
+        }
+        String escaped = LUCENE_PATTERN.matcher(value).replaceAll(REPLACEMENT_STRING);
+        return escaped;
+    }
+
 }

--- a/src/test/groovy/org/alliancegenome/api/QueryManipulationUnitSpec.groovy
+++ b/src/test/groovy/org/alliancegenome/api/QueryManipulationUnitSpec.groovy
@@ -33,6 +33,9 @@ class QueryManipulationUnitSpec extends Specification {
         "__primaryId:DOID:10314"              | "primaryId:DOID\\:10314"
         "si:ch211-133d24.26p"                 | "si\\:ch211-133d24.26p"
         "en::ftz::Mmus\\En1"                  | "en\\:\\:ftz\\:\\:Mmus\\En1"
+        "Foxn1<sup>nu-StL</sup> (Mmu)"        | "Foxn1\\<sup\\>nu-StL\\<\\/sup\\> (Mmu)"
+        "Gt(ROSA)26Sor<sup>tm1(Pik3ca*H1047R)Egan</sup> (Mmu)" | "Gt(ROSA)26Sor\\<sup\\>tm1(Pik3ca*H1047R)Egan\\<\\/sup\\> (Mmu)"
+
     }
 
 }


### PR DESCRIPTION
I'm sure we'll add more lucene escaping in the future, but since this is just going in as a hotfix, I didn't want to risk creating any new problems. 