### PR TITLE
Fix sitemap

### DIFF
--- a/src/main/java/org/alliancegenome/api/application/SiteMapCacherApplication.java
+++ b/src/main/java/org/alliancegenome/api/application/SiteMapCacherApplication.java
@@ -36,9 +36,14 @@ public class SiteMapCacherApplication {
 
     private SearchDAO searchDAO = new SearchDAO();
 
-    private final Integer fileSize = 5000;
+    private final Integer fileSize = 15000; // 15000 is the max that the index is configured with see site_index settings file
     private final HashMap<String, File> files = new HashMap<>();
 
+    public SiteMapCacherApplication() {
+        File dir = new File(System.getProperty("java.io.tmpdir") + "/sitemap/");
+        if(!dir.exists()) dir.mkdir();
+    }
+    
     public void init(@Observes @Initialized(ApplicationScoped.class) Object init) {
         if(ConfigHelper.getGenerateSitemap()) {
             log.info("Caching Sitemap Files: ");
@@ -55,10 +60,13 @@ public class SiteMapCacherApplication {
         }
     }
 
-    private void cacheSiteMap(String category) {
-
+    public void cacheSiteMap(String category) {
+        log.info("Getting all ids for: " + category);
+        
         List<SearchHit> allIds = searchDAO.getAllIds(termQuery("category", category), fileSize);
 
+        log.info("Finished Loading all ids: " + allIds.size());
+        
         List<XMLURL> urls = new ArrayList<XMLURL>();
 
         int c = 0;
@@ -88,16 +96,16 @@ public class SiteMapCacherApplication {
 
     private void saveFile(List<XMLURL> urls, String category, int c) {
         String fileName = category + "-sitemap-" + c;
-        String filePath = System.getProperty("jboss.server.temp.dir") + "/" + fileName;
+        String filePath = System.getProperty("java.io.tmpdir") + "/sitemap/" + fileName;
         files.put(fileName, new File(filePath));
-        log.debug("Saving File: " + filePath);
+        log.info("Saving File: " + filePath);
         save(urls, files.get(fileName));
     }
 
 
     public XMLURLSet getHits(String category, Integer page) {
         String fileName = category + "-sitemap-" + page;
-        log.debug("Loading: " + fileName);
+        log.info("Loading: " + fileName);
         XMLURLSet set = new XMLURLSet();
         if(files.containsKey(fileName)) {
             set.setUrl(load(files.get(fileName)));

--- a/src/main/java/org/alliancegenome/api/application/SiteMapCacherApplication.java
+++ b/src/main/java/org/alliancegenome/api/application/SiteMapCacherApplication.java
@@ -48,6 +48,7 @@ public class SiteMapCacherApplication {
         if(ConfigHelper.getGenerateSitemap()) {
             log.info("Caching Sitemap Files: ");
             cacheSiteMap("gene");
+            cacheSiteMap("allele");
             cacheSiteMap("disease");
             log.info("Caching Sitemap Files Finished: ");
         }

--- a/src/main/java/org/alliancegenome/api/application/SiteMapCacherApplication.java
+++ b/src/main/java/org/alliancegenome/api/application/SiteMapCacherApplication.java
@@ -91,7 +91,8 @@ public class SiteMapCacherApplication {
         if(urls.size() > 0) {
             saveFile(urls, category, c);
         }
-
+        urls.clear();
+        allIds.clear();
     }
 
     private void saveFile(List<XMLURL> urls, String category, int c) {

--- a/src/main/java/org/alliancegenome/api/application/SiteMapCacherApplication.java
+++ b/src/main/java/org/alliancegenome/api/application/SiteMapCacherApplication.java
@@ -61,17 +61,17 @@ public class SiteMapCacherApplication {
     }
 
     public void cacheSiteMap(String category) {
-        log.info("Getting all ids for: " + category);
+        log.debug("Getting all ids for: " + category);
         
-        List<SearchHit> allIds = searchDAO.getAllIds(termQuery("category", category), fileSize);
+        List<String> allIds = searchDAO.getAllIds(termQuery("category", category), fileSize);
 
-        log.info("Finished Loading all ids: " + allIds.size());
+        log.debug("Finished Loading all ids: " + allIds.size() + " for " + category);
         
         List<XMLURL> urls = new ArrayList<XMLURL>();
 
         int c = 0;
 
-        for(SearchHit hit: allIds) {
+        for(String id: allIds) {
             Date date = null;
 
             //System.out.println(hit.getFields());
@@ -80,7 +80,7 @@ public class SiteMapCacherApplication {
             //  date = new Date((long)hit.getSource().get("dateProduced"));
             //}
 
-            urls.add(new XMLURL(hit.getType() + "/" + hit.getId(), date, "monthly", "0.6"));
+            urls.add(new XMLURL(category + "/" + id, date, "monthly", "0.6"));
 
             if(urls.size() >= fileSize) {
                 saveFile(urls, category, c);
@@ -99,7 +99,7 @@ public class SiteMapCacherApplication {
         String fileName = category + "-sitemap-" + c;
         String filePath = System.getProperty("java.io.tmpdir") + "/sitemap/" + fileName;
         files.put(fileName, new File(filePath));
-        log.info("Saving File: " + filePath);
+        log.trace("Saving File: " + filePath);
         save(urls, files.get(fileName));
     }
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration>
 	<Properties>
 		<!-- Log levels can be changed via Env `export DEFAULT_LOG_LEVEL=DEBUG` -->
-		<Property name="DEFAULT_LOG_LEVEL">TRACE</Property>
+		<Property name="DEFAULT_LOG_LEVEL">DEBUG</Property>
 		<Property name="ES_LOG_LEVEL">WARN</Property>
 		<Property name="NETTY_LOG_LEVEL">WARN</Property>
 		<Property name="BOLT_LOG_LEVEL">WARN</Property>

--- a/src/test/java/org/alliancegenome/api/TestSiteMapGen.java
+++ b/src/test/java/org/alliancegenome/api/TestSiteMapGen.java
@@ -7,7 +7,9 @@ public class TestSiteMapGen {
     public static void main(String[] args) {
         SiteMapCacherApplication smca = new SiteMapCacherApplication();
         
-        smca.cacheSiteMap("gene");
+        //smca.cacheSiteMap("disease");
+        //smca.cacheSiteMap("gene");
+        smca.cacheSiteMap("allele");
 
     }
 

--- a/src/test/java/org/alliancegenome/api/TestSiteMapGen.java
+++ b/src/test/java/org/alliancegenome/api/TestSiteMapGen.java
@@ -1,0 +1,14 @@
+package org.alliancegenome.api;
+
+import org.alliancegenome.api.application.SiteMapCacherApplication;
+
+public class TestSiteMapGen {
+
+    public static void main(String[] args) {
+        SiteMapCacherApplication smca = new SiteMapCacherApplication();
+        
+        smca.cacheSiteMap("gene");
+
+    }
+
+}


### PR DESCRIPTION
This reduces the footprint of this method call, but only pulling ID from ES and not pulling the whole document. This hopefully will fix ES from crashing on deployment. Also adds Allele to the sitemap.